### PR TITLE
Fix Casing in Include Paths for Case-Sensitive Systems

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -81,9 +81,9 @@ set(COMPONENT_ADD_INCLUDEDIRS
 # "../libs/LITTLEFS/examples/LITTLEFS_test"
 
 "../libs/CleanGUI/src"
-"../libs/CleanGUI/src/Internals"
+"../libs/CleanGUI/src/internals"
 "../libs/CleanGUI_async/src"
-"../libs/CleanGUI_async/src/Internals"
+"../libs/CleanGUI_async/src/internals"
 "../libs/CleanGUI_extraTests/examples/Vec2"
 
 # "../libs/CleanGUI_for_TFT_eSPI/examples/Panel"
@@ -105,9 +105,9 @@ set(COMPONENT_ADD_INCLUDEDIRS
 # Belangrijk voor Arduino IDE code: de output van Serial Monitor
 # wordt naar een van de USB-ports van je devkit gestuurd. 
 # Als je toevallig programmeert via de andere, dan zie je niets.
-"../components/arduino-esp32/libraries/ESP32/examples/Analogread"
-"../components/arduino-esp32/libraries/WiFi/examples/WifiAccessPoint"
-"../components/arduino-esp32/libraries/WiFi/examples/WifiScan"
+"../components/arduino-esp32/libraries/ESP32/examples/AnalogRead"
+"../components/arduino-esp32/libraries/WiFi/examples/WiFiAccessPoint"
+"../components/arduino-esp32/libraries/WiFi/examples/WiFiScan"
 "../components/arduino-esp32/libraries/LittleFS/examples/LITTLEFS_test"
 
 "../apps/kopie_van_wifi_scan_example_van_esp_idf"


### PR DESCRIPTION
The CMakeLists.txt file contained include paths with incorrect casing, such as "Analogread" instead of "AnalogRead." This inconsistency caused issues on case-sensitive systems, preventing CMake from locating the correct paths. This pull request addresses and resolves the issue.